### PR TITLE
fix: `Net::Http::get_response` block argument not optional

### DIFF
--- a/gems/net-http/0.2/net-http.rbs
+++ b/gems/net-http/0.2/net-http.rbs
@@ -441,7 +441,7 @@ module Net
     #
     #    Net::HTTP.get_response(URI('http://www.example.com/index.html'), { 'Accept' => 'text/html' })
     #
-    def self.get_response: (untyped uri_or_host, ?untyped? path_or_headers, ?untyped? port) { () -> untyped } -> untyped
+    def self.get_response: (untyped uri_or_host, ?untyped? path_or_headers, ?untyped? port) ?{ () -> untyped } -> untyped
 
     # Posts data to the specified URI object.
     #


### PR DESCRIPTION
According to the [documentation](https://ruby-doc.org/stdlib-3.1.1/libdoc/net/http/rdoc/Net/HTTP.html#method-c-get_response), block is optional for `Net::Http::get_response`.