### PR TITLE
fix: remove duplicate definition of build

### DIFF
--- a/gems/newrelic_rpm/8.6/newrelic_rpm.rbs
+++ b/gems/newrelic_rpm/8.6/newrelic_rpm.rbs
@@ -6553,7 +6553,7 @@ module ActionDispatch
 
       alias build_without_new_relic build
 
-      alias build build_with_new_relic
+      # alias build build_with_new_relic
     end
   end
 end


### PR DESCRIPTION
```ruby
# actionpack-generated.rbs
module ActionDispatch
  class MiddlewareStack
    class Middleware
      def build: (untyped app) -> untyped
    end
  end
end
```

and

```ruby
# newrelic_rpm.rbs
module ActionDispatch
  class MiddlewareStack
    class Middleware
      def build_with_new_relic: (untyped app) -> untyped
      alias build build_with_new_relic
    end
  end
end
```

were conflicting.