### PR TITLE
Make GraphQL Argument block optional

### DIFF
--- a/gems/graphql/2.0/graphql.rbs
+++ b/gems/graphql/2.0/graphql.rbs
@@ -6086,7 +6086,7 @@ module GraphQL
 
         # @see {GraphQL::Schema::Argument#initialize} for parameters
         # @return [GraphQL::Schema::Argument] An instance of {argument_class}, created from `*args`
-        def argument: (*untyped args, **untyped kwargs) { () -> untyped } -> untyped
+        def argument: (*untyped args, **untyped kwargs) ?{ () -> untyped } -> untyped
 
         # Register this argument with the class.
         # @param arg_defn [GraphQL::Schema::Argument]


### PR DESCRIPTION
Corrects error in autogenrated graphql code
```
app/graphql/resolvers/settings_resolver.rb:10:4: [error] The method cannot be called without a block
│ Diagnostic ID: Ruby::RequiredBlockMissing
│
└     argument :property_id, String
      ~~~~~~~~
```
