### PR TITLE
fix: graphql argument block is optional for self.argument

### DIFF
--- a/gems/graphql/2.0/graphql.rbs
+++ b/gems/graphql/2.0/graphql.rbs
@@ -5823,7 +5823,7 @@ module GraphQL
       # Add an argument to this field's signature, but
       # also add some preparation hook methods which will be used for this argument
       # @see {GraphQL::Schema::Argument#initialize} for the signature
-      def self.argument: (*untyped args, **untyped kwargs) { () -> untyped } -> untyped
+      def self.argument: (*untyped args, **untyped kwargs) ?{ () -> untyped } -> untyped
 
       # Registers new extension
       # @param extension [Class] Extension class
@@ -6086,7 +6086,7 @@ module GraphQL
 
         # @see {GraphQL::Schema::Argument#initialize} for parameters
         # @return [GraphQL::Schema::Argument] An instance of {argument_class}, created from `*args`
-        def argument: (*untyped args, **untyped kwargs) ?{ () -> untyped } -> untyped
+        def argument: (*untyped args, **untyped kwargs) { () -> untyped } -> untyped
 
         # Register this argument with the class.
         # @param arg_defn [GraphQL::Schema::Argument]


### PR DESCRIPTION
follow up on #11
fixes https://app.circleci.com/pipelines/github/appfolio/revenue-management/260/workflows/ea31948a-9fef-42ef-ac4c-001e7551c6bf/jobs/2188

```
app/graphql/resolvers/settings_resolver.rb:8:4: [error] The method cannot be called without a block
│ Diagnostic ID: Ruby::RequiredBlockMissing
│
└     argument :vhost, String
      ~~~~~~~~
```