### PR TITLE
fix: active record `joins` not typed

### DIFF
--- a/gems/activerecord/6.0/activerecord.rbs
+++ b/gems/activerecord/6.0/activerecord.rbs
@@ -37,6 +37,7 @@ module ActiveRecord
     extend ::ActiveRecord::Transactions::ClassMethods
     extend ::ActiveRecord::Validations::ClassMethods
     extend ::ActiveSupport::Callbacks::ClassMethods
+    extend _ActiveRecord_Relation_ClassMethods[untyped, untyped, untyped]
 
     def self.abstract_class=: (bool) -> void
     def self.scope: (Symbol, Proc) ?{ () -> untyped } -> void


### PR DESCRIPTION
fix: active record `joins` not typed

